### PR TITLE
Options for configuring the repository text

### DIFF
--- a/lib/Pod/Weaver/Section/Support.pm
+++ b/lib/Pod/Weaver/Section/Support.pm
@@ -61,6 +61,9 @@ sub weave_section {
 			}
 		}
 
+		# warn the user if any of the desired links are blank
+		$zilla->log_fatal("Expected repository link not found") if grep { !$_ } @repo_links;
+
 		if ( $self->repository_content ){
 			chomp($repository_content = $self->repository_content);
 			$repository_content .= "\n\n";
@@ -194,6 +197,9 @@ Valid options are: "url", "web", "both", or "none".
 "none" will skip the repository item entirely.
 
 The default is "url".
+
+An error will be thrown if a specified link is not found
+because if you said that you wanted it you probably expect it to be there.
 
 =item * repository_content
 

--- a/lib/Pod/Weaver/Section/Support.pm
+++ b/lib/Pod/Weaver/Section/Support.pm
@@ -8,6 +8,28 @@ use Moose::Autobox 0.10;
 use Pod::Weaver::Role::Section 3.100710;
 with 'Pod::Weaver::Role::Section';
 
+{
+	use Moose::Util::TypeConstraints 1.01;
+
+	has repository_link => (
+		is => 'ro',
+		isa => enum( [ qw( both none url web ) ] ),
+		default => 'url'
+	);
+
+	no Moose::Util::TypeConstraints;
+}
+
+has repository_content => (
+	is => 'ro',
+	isa => 'Str',
+	default => <<EOPOD
+The code is open to the world, and available for you to hack on. Please feel free to browse it and play
+with it, or whatever. If you want to contribute patches, please send me a diff or prod me to pull
+from your repository :)
+EOPOD
+);
+
 sub weave_section {
 	## no critic ( ProhibitAccessOfPrivateData )
 	my ($self, $document, $input) = @_;
@@ -24,13 +46,26 @@ sub weave_section {
 	my $perl_name = $dist;
 	$perl_name =~ s/-/::/g;
 	my $repository;
-	if ( exists $zilla->distmeta->{resources}{repository} ) {
+	my $repository_content = '';
+	if ( exists $zilla->distmeta->{resources}{repository} && $self->repository_link ne 'none' ) {
 		$repository = $zilla->distmeta->{resources}{repository};
+		my @repo_links = $repository;
 
 		# for dzil v3 with CPAN Meta v2
 		if ( ref $repository ) {
-			$repository = $repository->{url};
+			if( $self->repository_link eq 'both' ){
+				@repo_links = @{$repository}{qw(url web)};
+			} else {
+				# enum restricts this value to appropriate options
+				@repo_links = $repository->{ $self->repository_link };
+			}
 		}
+
+		if ( $self->repository_content ){
+			chomp($repository_content = $self->repository_content);
+			$repository_content .= "\n\n";
+		}
+		$repository_content .= join("\n\n", map { "L<$_>" } @repo_links);
 	}
 
 	$document->children->push(
@@ -74,16 +109,8 @@ EOPOD
 								_make_item( 'CPAN Testers Results', "L<http://cpantesters.org/distro/$first_char/$dist.html>" ),
 								_make_item( 'CPAN Testers Matrix', "L<http://matrix.cpantesters.org/?dist=$dist>" ),
 							( defined $repository ?
-								_make_item( 'Source Code Repository', <<EOPOD
-The code is open to the world, and available for you to hack on. Please feel free to browse it and play
-with it, or whatever. If you want to contribute patches, please send me a diff or prod me to pull
-from your repository :)
-
-L<$repository>
-EOPOD
-
-								)
-: () ),
+								_make_item( 'Source Code Repository', $repository_content )
+								: () ),
 								Pod::Elemental::Element::Pod5::Command->new( {
 									command => 'back',
 									content => '',
@@ -150,5 +177,30 @@ This is added B<ONLY> to the main module's POD, because it would be a waste of s
 modules in the dist.
 
 For an example of what the hunk looks like, look at the L</SUPPORT> section in this POD :)
+
+=head1 OPTIONS
+
+=over 4
+
+=item * repository_link
+
+Specify which url to use when composing the external link.
+The value corresponds to the repository meta resources (for dzil v3 with CPAN Meta v2).
+
+Valid options are: "url", "web", "both", or "none".
+
+"both" will include links to both the "url" and "web" in separate POD paragraphs.
+
+"none" will skip the repository item entirely.
+
+The default is "url".
+
+=item * repository_content
+
+Text displayed before the link to the source code repository.
+
+The default is a sufficient explanation (see L</SUPPORT>).
+
+=back
 
 =cut


### PR DESCRIPTION
I added options for altering the display of the Source Code Repository item in SUPPORT/Websites.

One for configuring which repository url will be displayed ('url' or 'web' (or both or none)),
and one for specifying alternate content before the link (assuming the previous choice wasn't "none").

I left the defaults at your previous values.

What do you think?
