### PR TITLE
Log via self instead of zilla for better prefixes.

### DIFF
--- a/lib/Pod/Weaver/Section/Support.pm
+++ b/lib/Pod/Weaver/Section/Support.pm
@@ -510,7 +510,10 @@ sub _add_repo {
 	if ( exists $zilla->distmeta->{resources}{repository} ) {
 		$repo = $zilla->distmeta->{resources}{repository};
 	} else {
-		$self->log_fatal( [ "Repository information missing and you wanted: %s", $self->repository_link ] );
+		$self->log_fatal( [
+			"Repository information in meta.resources.repository is missing and you wanted: %s",
+			$self->repository_link eq 'both' ? 'both (web and url)' : $self->repository_link,
+		] );
 	}
 
 	my $text = join( "\n", @{ $self->repository_content } );

--- a/lib/Pod/Weaver/Section/Support.pm
+++ b/lib/Pod/Weaver/Section/Support.pm
@@ -363,20 +363,20 @@ sub _add_bugs {
 		$text =~ s/\{EMAIL\}/$mailto/;
 	} else {
 		# code copied from Pod::Weaver::Section::Bugs, thanks RJBS!
-		$zilla->log_fatal( 'No bugtracker in metadata!' ) unless exists $distmeta->{resources}{bugtracker};
+		$self->log_fatal( 'No bugtracker in metadata!' ) unless exists $distmeta->{resources}{bugtracker};
 		my $bugtracker = $distmeta->{resources}{bugtracker};
 		my( $web, $mailto ) = @{$bugtracker}{qw/web mailto/};
-		$zilla->log_fatal( 'No bugtracker in metadata!' ) unless defined $web || defined $mailto;
+		$self->log_fatal( 'No bugtracker in metadata!' ) unless defined $web || defined $mailto;
 
 		$text =~ s/\{WEB\}/L\<$web\>/ if defined $web;
 		$text =~ s/\{EMAIL\}/C\<$mailto\>/ if defined $mailto;
 
 		# sanity check the content
 		if ( $text =~ /\{WEB\}/ ) {
-			$zilla->log_fatal( "The metadata doesn't have a website for the bugtracker but you specified it in the bugs_content!" );
+			$self->log_fatal( "The metadata doesn't have a website for the bugtracker but you specified it in the bugs_content!" );
 		}
 		if ( $text =~ /\{EMAIL\}/ ) {
-			$zilla->log_fatal( "The metadata doesn't have an email for the bugtracker but you specified it in the bugs_content!" );
+			$self->log_fatal( "The metadata doesn't have an email for the bugtracker but you specified it in the bugs_content!" );
 		}
 	}
 
@@ -510,7 +510,7 @@ sub _add_repo {
 	if ( exists $zilla->distmeta->{resources}{repository} ) {
 		$repo = $zilla->distmeta->{resources}{repository};
 	} else {
-		$zilla->log_fatal( [ "Repository information missing and you wanted: %s", $self->repository_link ] );
+		$self->log_fatal( [ "Repository information missing and you wanted: %s", $self->repository_link ] );
 	}
 
 	my $text = join( "\n", @{ $self->repository_content } );
@@ -523,13 +523,13 @@ sub _add_repo {
 			if ( exists $repo->{web} ) {
 				$text .= 'L<' . $repo->{web} . ">";
 			} else {
-				$zilla->log_fatal("Expected to find 'web' repository link but it is missing in the metadata!");
+				$self->log_fatal("Expected to find 'web' repository link but it is missing in the metadata!");
 			}
 		}
 
 		if ( $self->repository_link eq 'url' or $self->repository_link eq 'both' ) {
 			if ( ! exists $repo->{url} ) {
-				$zilla->log_fatal("Expected to find 'url' repository link but it is missing in the metadata!");
+				$self->log_fatal("Expected to find 'url' repository link but it is missing in the metadata!");
 			}
 
 			if ( $self->repository_link eq 'both' ) {
@@ -558,7 +558,7 @@ sub _add_repo {
 			}
 		}
 	} else {
-		$zilla->log_warning("You need to update Dist::Zilla::Plugin::Repository to at least v0.15 for the correct metadata!");
+		$self->log_warning("You need to update Dist::Zilla::Plugin::Repository to at least v0.15 for the correct metadata!");
 		$text .= "L<$repo>";
 	}
 
@@ -599,7 +599,7 @@ sub _add_websites {
 	# sanity check
 	foreach my $type ( @{ $self->websites } ) {
 		if ( $type !~ /^(?:search|rt|anno|ratings|forum|kwalitee|testers|testmatrix|deps|all)$/i ) {
-			$zilla->log_fatal( "Unknown website type: $type" );
+			$self->log_fatal( "Unknown website type: $type" );
 		}
 	}
 


### PR DESCRIPTION
As explained by @RJBS on bug rt#69033

  https://rt.cpan.org/Public/Bug/Display.html?id=69033

If you call `$self->log_*` instead of `$zilla->log_*` , a whole bunch of
prefixing magic will occur, and this will mean instead of the useless

```
Repository information missing and you wanted: both
```

Appearing seemingly out of nowhere, where you have to randomly turn off
modules in Dist.ini _just_ to discover it happens during `POD::Weaver`,
and _then_ spending time to realise their dzil bundle secretly also
loads a `Pod::Weaver` bundle, and _then_ realise that `Section` is to
blame by reading the source for the `Section` plugin ( a reasonably
painful chain of events I assure you ), instead, you get:

```
[@Filter/PodWeaver] [@DAGOLDEN/Support] Repository information missing
and you wanted: both
```

or something similar, Which is about a thousand times more informative.
